### PR TITLE
Add Instagram support and configurable data sources

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,14 @@ REDDIT_CLIENT_ID=your_reddit_client_id
 REDDIT_CLIENT_SECRET=your_reddit_client_secret
 REDDIT_USER_AGENT=your_app_name
 # Facebook scraping uses public pages; no API key required.
+# Instagram scraping uses public profiles; no API key required.
+
+# Enable or disable data sources (1 = on, 0 = off)
+ENABLE_TWITTER=1
+ENABLE_REDDIT=1
+ENABLE_NEWS=1
+ENABLE_FACEBOOK=1
+ENABLE_INSTAGRAM=1
 
 # Email settings for daily digests (optional)
 SMTP_HOST=smtp.example.com

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Social & News Monitoring Dashboard
 
-A Streamlit-based dashboard for tracking people or topics across Twitter, Reddit, Facebook and news sites.
+A Streamlit-based dashboard for tracking people or topics across Twitter, Reddit, Facebook, Instagram and news sites.
 
 ## Features
 
 - Add topics with custom keywords
-- Automatic collection from Twitter (snscrape), Reddit (PRAW), public Facebook pages (facebook-scraper) and News (NewsAPI or Google News RSS)
+- Automatic collection from Twitter (snscrape), Reddit (PRAW), public Facebook pages (facebook-scraper), public Instagram profiles (instaloader) and News (NewsAPI or Google News RSS)
 - SQLite database storage using SQLAlchemy
 - Word clouds, time series charts and AI summaries (supports local models via Ollama or HuggingFace)
 - Daily scheduled collection and optional email digests
+- Toggle individual sources on or off as needed
 
 ## Beginner-Friendly Setup Guide
 
@@ -62,6 +63,8 @@ All values are **optional**. Without them the app still works using free public 
 - **SMTP settings** – needed only if you want daily email digests.
 - **OLLAMA_MODEL** – install [Ollama](https://ollama.ai) and run `ollama pull qwen:latest`, then set `OLLAMA_MODEL=qwen` for local AI summaries.
 - **Facebook pages** – no key required. When adding a topic, include public Facebook page URLs in the **Profiles** field to collect their posts.
+- **Instagram profiles** – no key required. Include public Instagram profile URLs in **Profiles** to collect their posts.
+- **ENABLE_*** variables – set `ENABLE_TWITTER`, `ENABLE_REDDIT`, `ENABLE_NEWS`, `ENABLE_FACEBOOK` or `ENABLE_INSTAGRAM` to `0` in `.env` (or use the sidebar checkboxes) to disable specific sources.
 
 ### 6. Run the Dashboard
 

--- a/app.py
+++ b/app.py
@@ -51,6 +51,13 @@ except Exception:
         "Facebook scraping requires the `facebook-scraper` package. Install with `pip install \"facebook-scraper[lxml]\" lxml_html_clean` to enable."
     )
 
+try:
+    import instaloader  # type: ignore  # noqa: F401
+except Exception:
+    st.sidebar.info(
+        "Instagram scraping requires the `instaloader` package. Install with `pip install instaloader` to enable."
+    )
+
 if not os.getenv("SMTP_HOST") or not os.getenv("SMTP_USER"):
     st.sidebar.info(
         "Email digests disabled. Set SMTP_HOST, SMTP_PORT, SMTP_USER and SMTP_PASSWORD in .env to enable."
@@ -67,7 +74,30 @@ if scheduler is None:
         "Background scheduler did not start. Scheduled collection won't run; check logs or collect manually."
     )
 
-# Sidebar for adding topics
+# Sidebar for data source toggles and adding topics
+st.sidebar.header("Data Sources")
+enable_twitter = st.sidebar.checkbox(
+    "Twitter", value=os.getenv("ENABLE_TWITTER", "1") == "1"
+)
+enable_reddit = st.sidebar.checkbox(
+    "Reddit", value=os.getenv("ENABLE_REDDIT", "1") == "1"
+)
+enable_news = st.sidebar.checkbox(
+    "News", value=os.getenv("ENABLE_NEWS", "1") == "1"
+)
+enable_facebook = st.sidebar.checkbox(
+    "Facebook", value=os.getenv("ENABLE_FACEBOOK", "1") == "1"
+)
+enable_instagram = st.sidebar.checkbox(
+    "Instagram", value=os.getenv("ENABLE_INSTAGRAM", "1") == "1"
+)
+
+os.environ["ENABLE_TWITTER"] = "1" if enable_twitter else "0"
+os.environ["ENABLE_REDDIT"] = "1" if enable_reddit else "0"
+os.environ["ENABLE_NEWS"] = "1" if enable_news else "0"
+os.environ["ENABLE_FACEBOOK"] = "1" if enable_facebook else "0"
+os.environ["ENABLE_INSTAGRAM"] = "1" if enable_instagram else "0"
+
 st.sidebar.header("Add / Manage Topics")
 name = st.sidebar.text_input("Topic or Person")
 keywords = st.sidebar.text_input("Keywords (comma separated)")

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ollama
 feedparser
 facebook-scraper
 lxml_html_clean
+requests


### PR DESCRIPTION
## Summary
- scrape public Instagram profiles with fallback request-based parser and private-profile notices
- allow enabling or disabling Twitter, Reddit, News, Facebook and Instagram sources via sidebar toggles or `.env`
- document new Instagram support and feature toggles

## Testing
- `python -m py_compile app.py monitoring/collectors.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6894c185e3cc8326a0d1f2821add82f1