### PR TITLE
Fix HTML content rendering and refine underline style

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,6 +53,19 @@ def contains_hebrew(text: str) -> bool:
     return bool(HEBREW_RE.search(text))
 
 
+def fully_unescape(text: str) -> str:
+    """Repeatedly unescape HTML entities until fully resolved."""
+    import html
+
+    previous = None
+    current = text
+    # Continue unescaping until there's no change
+    while current != previous:
+        previous = current
+        current = html.unescape(current)
+    return current
+
+
 @st.dialog("AI Summary")
 def show_link_summary(content: str) -> None:
     """Display a modal summarising a post's content."""
@@ -134,6 +147,11 @@ st.markdown("""
     
     .sidebar .stSelectbox > div > div > div {
         background-color: #f0f2f6;
+    }
+
+    u {
+        text-underline-offset: 2px;
+        text-decoration-thickness: 2px;
     }
 </style>
 """, unsafe_allow_html=True)
@@ -625,10 +643,10 @@ else:
             Uses a single HTML block with all dynamic content escaped to avoid leaking HTML.
             """
             # Clean the content for display
-            raw_content = strip_think(str(row["content"]))
             import re as _re
             import html as _html
 
+            raw_content = fully_unescape(strip_think(str(row["content"])))
             # Plain text content
             content = _re.sub(r"<[^>]+>", "", raw_content).strip()
 
@@ -751,8 +769,8 @@ else:
 
         def render_post(row, key_prefix: str, in_columns: bool = False) -> None:
             # Clean the content for display
-            raw_content = strip_think(str(row["content"]))
             import re
+            raw_content = fully_unescape(strip_think(str(row["content"])))
             content = re.sub(r'<[^>]+>', '', raw_content)[:200]
             
             age = time_ago(row["posted_at"])


### PR DESCRIPTION
## Summary
- Fully decode stored HTML entities before stripping tags so posts render clean text instead of raw markup
- Reuse this decoding for post rendering to keep subject underlines and other styling intact

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897927e68fc8326a5b36f38ef54da3b